### PR TITLE
chore: upgrade to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   },
-  "packageManager": "pnpm@10.29.2+sha512.bef43fa759d91fd2da4b319a5a0d13ef7a45bb985a3d7342058470f9d2051a3ba8674e629672654686ef9443ad13a82da2beb9eeb3e0221c87b8154fff9d74b8",
+  "packageManager": "pnpm@11.0.9+sha512.34ce82e6780233cf9cad8685029a8f81d2e06196c5a9bad98879f7424940c6817c4e4524fb7d38b8553ceed48b9758b8ebaf1abd3600c232c4c8cf7366086f38",
   "engines": {
     "node": ">=24"
   },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   },
-  "packageManager": "pnpm@11.0.9+sha512.34ce82e6780233cf9cad8685029a8f81d2e06196c5a9bad98879f7424940c6817c4e4524fb7d38b8553ceed48b9758b8ebaf1abd3600c232c4c8cf7366086f38",
+  "packageManager": "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f",
   "engines": {
     "node": ">=24"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-onlyBuiltDependencies:
-  - esbuild
-  - lefthook
+allowBuilds:
+  esbuild: true
+  lefthook: true


### PR DESCRIPTION
## Summary

Upgrade this repo to pnpm 11 following the [v10 → v11 migration guide](https://pnpm.io/11.x/migration).

- `package.json#packageManager` bumped to `pnpm@11.0.9` (with integrity hash).
- `pnpm-workspace.yaml#onlyBuiltDependencies` (list) converted to `allowBuilds` (map) per the codemod's automatic transform — same `esbuild` and `lefthook` entries, just the new shape.
- No `.npmrc` settings to migrate (registry/auth only, which v11 still reads from `.npmrc`).
- `pnpm-lock.yaml` is unchanged (still `lockfileVersion: '9.0'`); pnpm 11 keeps the same lockfile format. `pnpm install` is a no-op against the existing lock.
- Locally ran the same scripts that CI runs (`pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test -- --run`, plus `pnpm build`) — all pass.

## Review & Testing Checklist for Human

- [ ] CI green on `code-quality.yaml`.
- [ ] Next semantic release publishes correctly under pnpm 11.

### Notes

Part of a coordinated pnpm 11 rollout across the geostrategists repos.

Link to Devin session: https://app.devin.ai/sessions/87672c10d0d44a419c25c00cc2cedf32
Requested by: @oxc