### PR TITLE
doc: update README install/dev scripts from yarn to pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ the JWKS file (after a configurable grace period).
 ## Installation
 
 ```bash
+npm install @geostrategists/cdk-jwks-rotation
+# or
 pnpm add @geostrategists/cdk-jwks-rotation
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ the JWKS file (after a configurable grace period).
 ## Installation
 
 ```bash
-npm install @geostrategists/cdk-jwks-rotation
-# or
-yarn add @geostrategists/cdk-jwks-rotation
+pnpm add @geostrategists/cdk-jwks-rotation
 ```
 
 ## Types
@@ -107,9 +105,9 @@ The construct grants the rotation Lambda:
 
 Install and scripts:
 ```bash
-yarn install
-yarn lint
-yarn typecheck
-yarn build
-yarn test:run
+pnpm install
+pnpm lint
+pnpm typecheck
+pnpm build
+pnpm test:run
 ```


### PR DESCRIPTION
## Summary
README still showed `yarn add` / `yarn install` etc. — but the repo migrated to pnpm/corepack in #3, and `package.json#packageManager` is now `pnpm@…`. Bringing the README in line.

- Installation block: collapsed `npm install` + `yarn add` alternatives to a single `pnpm add @geostrategists/cdk-jwks-rotation`, matching the convention used in `vite-library-package-json`'s README.
- Development block: `yarn {install,lint,typecheck,build,test:run}` → `pnpm {install,lint,typecheck,build,test:run}`. All four scripts exist in `package.json` already (`lint`, `typecheck`, `build`, `test:run`).


Link to Devin session: https://app.devin.ai/sessions/87672c10d0d44a419c25c00cc2cedf32
Requested by: @oxc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/geostrategists/cdk-jwks-rotation/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->