### PR TITLE
style: increase biome print width to 120

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,7 @@
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "lineWidth": 100
+    "lineWidth": 120
   },
   "linter": {
     "enabled": true,

--- a/src/lambda/create-secret.ts
+++ b/src/lambda/create-secret.ts
@@ -4,12 +4,7 @@ import { exportJWK, exportPKCS8, type GenerateKeyPairResult, generateKeyPair } f
 import { nanoid } from "nanoid";
 import type { KeySpec } from "../jwks-rotation";
 import type { SecretValue } from "./types";
-import {
-  getEnvironmentConfig,
-  getSecretValue,
-  putSecretValue,
-  regenerateAndPublishJwks,
-} from "./utils";
+import { getEnvironmentConfig, getSecretValue, putSecretValue, regenerateAndPublishJwks } from "./utils";
 
 export async function createSecret(
   secretsClient: SecretsManagerClient,
@@ -35,9 +30,7 @@ export async function createSecret(
 
   if (!nextSecret) {
     if (currentSecret?.secretValue.activatedAt) {
-      console.log(
-        "No NEXT key exists but current key found. Creating NEXT key and aborting rotation.",
-      );
+      console.log("No NEXT key exists but current key found. Creating NEXT key and aborting rotation.");
       const newNextKeyPair = await generateJwksKeyPair(keySpec);
 
       await putSecretValue(secretsClient, {
@@ -56,9 +49,7 @@ export async function createSecret(
       throw new Error("Created NEXT key. Aborting rotation as requested.");
     }
 
-    console.log(
-      "No current secret or current in initial state. Creating key for immediate activation.",
-    );
+    console.log("No current secret or current in initial state. Creating key for immediate activation.");
     const keyPair = await generateJwksKeyPair(keySpec);
     nextKeyData = keyPair.secretValue;
   } else {

--- a/src/lambda/finish-secret.ts
+++ b/src/lambda/finish-secret.ts
@@ -1,8 +1,5 @@
 import type { S3Client } from "@aws-sdk/client-s3";
-import {
-  type SecretsManagerClient,
-  UpdateSecretVersionStageCommand,
-} from "@aws-sdk/client-secrets-manager";
+import { type SecretsManagerClient, UpdateSecretVersionStageCommand } from "@aws-sdk/client-secrets-manager";
 import { getSecretValue, regenerateAndPublishJwks } from "./utils";
 
 export async function finishSecret(

--- a/src/lambda/utils.ts
+++ b/src/lambda/utils.ts
@@ -128,11 +128,7 @@ export async function putSecretValue(
   await client.send(command);
 }
 
-export async function getJwksFromS3(
-  client: S3Client,
-  bucketName: string,
-  key: string,
-): Promise<JSONWebKeySet> {
+export async function getJwksFromS3(client: S3Client, bucketName: string, key: string): Promise<JSONWebKeySet> {
   try {
     const command = new GetObjectCommand({
       Bucket: bucketName,
@@ -186,8 +182,7 @@ export async function buildJwks(
   secretId: string,
   options?: BuildJwksOptions,
 ): Promise<JSONWebKeySet> {
-  const { minKeyCleanupGracePeriodSeconds, maxTokenValidityDurationSeconds } =
-    getEnvironmentConfig();
+  const { minKeyCleanupGracePeriodSeconds, maxTokenValidityDurationSeconds } = getEnvironmentConfig();
 
   const keys: JWK[] = [];
 
@@ -219,8 +214,7 @@ export async function buildJwks(
 
     if (
       !currentActivatedAgoSeconds ||
-      currentActivatedAgoSeconds <=
-        maxTokenValidityDurationSeconds + minKeyCleanupGracePeriodSeconds
+      currentActivatedAgoSeconds <= maxTokenValidityDurationSeconds + minKeyCleanupGracePeriodSeconds
     ) {
       addJwk(previous);
     }

--- a/tests/lambda/cleanup-expired-keys.test.ts
+++ b/tests/lambda/cleanup-expired-keys.test.ts
@@ -23,8 +23,7 @@ import { cleanupExpiredKeys } from "../../src/lambda/cleanup-expired-keys";
 const s3Mock = mockClient(S3Client);
 const secretsManagerMock = mockClient(SecretsManagerClient);
 const mockedS3Client: S3Client = s3Mock as unknown as S3Client;
-const mockedSecretsManagerClient: SecretsManagerClient =
-  secretsManagerMock as unknown as SecretsManagerClient;
+const mockedSecretsManagerClient: SecretsManagerClient = secretsManagerMock as unknown as SecretsManagerClient;
 
 describe("Cleanup Expired Keys", () => {
   beforeEach(() => {
@@ -254,8 +253,8 @@ describe("Cleanup Expired Keys", () => {
 
     s3Mock.on(PutObjectCommand).rejects(new Error("S3 Error"));
 
-    await expect(
-      cleanupExpiredKeys(mockedSecretsManagerClient, mockedS3Client, "test-secret-arn"),
-    ).rejects.toThrow("S3 Error");
+    await expect(cleanupExpiredKeys(mockedSecretsManagerClient, mockedS3Client, "test-secret-arn")).rejects.toThrow(
+      "S3 Error",
+    );
   });
 });

--- a/tests/lambda/create-secret.test.ts
+++ b/tests/lambda/create-secret.test.ts
@@ -1,9 +1,5 @@
 import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import {
-  GetSecretValueCommand,
-  PutSecretValueCommand,
-  SecretsManagerClient,
-} from "@aws-sdk/client-secrets-manager";
+import { GetSecretValueCommand, PutSecretValueCommand, SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
 import { mockClient } from "aws-sdk-client-mock";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -26,8 +22,7 @@ import { createSecret } from "../../src/lambda/create-secret";
 const s3Mock = mockClient(S3Client);
 const secretsManagerMock = mockClient(SecretsManagerClient);
 const mockedS3Client: S3Client = s3Mock as unknown as S3Client;
-const mockedSecretsManagerClient: SecretsManagerClient =
-  secretsManagerMock as unknown as SecretsManagerClient;
+const mockedSecretsManagerClient: SecretsManagerClient = secretsManagerMock as unknown as SecretsManagerClient;
 
 describe("Create Secret", () => {
   beforeEach(() => {
@@ -119,9 +114,9 @@ describe("Create Secret", () => {
         VersionStages: ["NEXT"],
       });
 
-    await expect(
-      createSecret(secretsManagerMock as any, s3Mock as any, "test-secret", "test-token"),
-    ).rejects.toThrow("Next key is too new");
+    await expect(createSecret(secretsManagerMock as any, s3Mock as any, "test-secret", "test-token")).rejects.toThrow(
+      "Next key is too new",
+    );
 
     expect(secretsManagerMock.commandCalls(PutSecretValueCommand)).toHaveLength(0);
   });
@@ -142,9 +137,9 @@ describe("Create Secret", () => {
   it("should handle secrets manager errors", async () => {
     secretsManagerMock.on(GetSecretValueCommand).rejects(new Error("SecretsManager Error"));
 
-    await expect(
-      createSecret(secretsManagerMock as any, s3Mock as any, "test-secret", "test-token"),
-    ).rejects.toThrow("SecretsManager Error");
+    await expect(createSecret(secretsManagerMock as any, s3Mock as any, "test-secret", "test-token")).rejects.toThrow(
+      "SecretsManager Error",
+    );
   });
 
   it("should generate ES256 keys correctly", async () => {
@@ -199,9 +194,9 @@ describe("Create Secret", () => {
     });
     s3Mock.on(PutObjectCommand).resolves({});
 
-    await expect(
-      createSecret(secretsManagerMock as any, s3Mock as any, "test-secret", "test-token"),
-    ).rejects.toThrow("Created NEXT key. Aborting rotation as requested.");
+    await expect(createSecret(secretsManagerMock as any, s3Mock as any, "test-secret", "test-token")).rejects.toThrow(
+      "Created NEXT key. Aborting rotation as requested.",
+    );
 
     const putCalls = secretsManagerMock.commandCalls(PutSecretValueCommand);
     expect(putCalls).toHaveLength(1);

--- a/tests/lambda/finish-secret.test.ts
+++ b/tests/lambda/finish-secret.test.ts
@@ -26,8 +26,7 @@ import { finishSecret } from "../../src/lambda/finish-secret";
 const s3Mock = mockClient(S3Client);
 const secretsManagerMock = mockClient(SecretsManagerClient);
 const mockedS3Client: S3Client = s3Mock as unknown as S3Client;
-const mockedSecretsManagerClient: SecretsManagerClient =
-  secretsManagerMock as unknown as SecretsManagerClient;
+const mockedSecretsManagerClient: SecretsManagerClient = secretsManagerMock as unknown as SecretsManagerClient;
 
 describe("Finish Secret", () => {
   beforeEach(() => {
@@ -102,9 +101,9 @@ describe("Finish Secret", () => {
       })
       .rejects({ name: "ResourceNotFoundException" });
 
-    await expect(
-      finishSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token"),
-    ).rejects.toThrow("Current version not found");
+    await expect(finishSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token")).rejects.toThrow(
+      "Current version not found",
+    );
   });
 
   it("should add deactivation timestamp to previous version", async () => {
@@ -163,9 +162,9 @@ describe("Finish Secret", () => {
   it("should handle secrets manager errors", async () => {
     secretsManagerMock.on(GetSecretValueCommand).rejects(new Error("SecretsManager Error"));
 
-    await expect(
-      finishSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token"),
-    ).rejects.toThrow("SecretsManager Error");
+    await expect(finishSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token")).rejects.toThrow(
+      "SecretsManager Error",
+    );
   });
 
   it("should handle update version stage errors", async () => {
@@ -183,8 +182,8 @@ describe("Finish Secret", () => {
 
     secretsManagerMock.on(UpdateSecretVersionStageCommand).rejects(new Error("Update Error"));
 
-    await expect(
-      finishSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token"),
-    ).rejects.toThrow("Update Error");
+    await expect(finishSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token")).rejects.toThrow(
+      "Update Error",
+    );
   });
 });

--- a/tests/lambda/test-secret.test.ts
+++ b/tests/lambda/test-secret.test.ts
@@ -7,8 +7,7 @@ import { testSecret } from "../../src/lambda/test-secret";
 const s3Mock = mockClient(S3Client);
 const secretsManagerMock = mockClient(SecretsManagerClient);
 const mockedS3Client: S3Client = s3Mock as unknown as S3Client;
-const mockedSecretsManagerClient: SecretsManagerClient =
-  secretsManagerMock as unknown as SecretsManagerClient;
+const mockedSecretsManagerClient: SecretsManagerClient = secretsManagerMock as unknown as SecretsManagerClient;
 
 vi.mock("../../src/lambda/utils", async () => {
   const actual = await vi.importActual("../../src/lambda/utils");
@@ -108,9 +107,9 @@ zTxPPg/R3Ih9XuBRmrGGqhAH
   it("should throw error when AWSPENDING secret not found", async () => {
     secretsManagerMock.on(GetSecretValueCommand).rejects({ name: "ResourceNotFoundException" });
 
-    await expect(
-      testSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token"),
-    ).rejects.toThrow("AWSPENDING version not found");
+    await expect(testSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token")).rejects.toThrow(
+      "AWSPENDING version not found",
+    );
   });
 
   it("should throw error when JWKS file not found", async () => {
@@ -127,9 +126,9 @@ zTxPPg/R3Ih9XuBRmrGGqhAH
 
     s3Mock.on(GetObjectCommand).rejects({ name: "NoSuchKey" });
 
-    await expect(
-      testSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token"),
-    ).rejects.toThrow("No keys found in JWKS document");
+    await expect(testSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token")).rejects.toThrow(
+      "No keys found in JWKS document",
+    );
   });
 
   it("should throw error when key not found in JWKS", async () => {
@@ -164,9 +163,9 @@ zTxPPg/R3Ih9XuBRmrGGqhAH
       } as any,
     });
 
-    await expect(
-      testSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token"),
-    ).rejects.toThrow("no applicable key found in the JSON Web Key Set");
+    await expect(testSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token")).rejects.toThrow(
+      "no applicable key found in the JSON Web Key Set",
+    );
   });
 
   it("should handle S3 errors", async () => {
@@ -183,16 +182,16 @@ zTxPPg/R3Ih9XuBRmrGGqhAH
 
     s3Mock.on(GetObjectCommand).rejects(new Error("S3 Error"));
 
-    await expect(
-      testSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token"),
-    ).rejects.toThrow("S3 Error");
+    await expect(testSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token")).rejects.toThrow(
+      "S3 Error",
+    );
   });
 
   it("should handle secrets manager errors", async () => {
     secretsManagerMock.on(GetSecretValueCommand).rejects(new Error("SecretsManager Error"));
 
-    await expect(
-      testSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token"),
-    ).rejects.toThrow("SecretsManager Error");
+    await expect(testSecret(mockedSecretsManagerClient, mockedS3Client, "test-secret", "test-token")).rejects.toThrow(
+      "SecretsManager Error",
+    );
   });
 });

--- a/tests/lambda/utils.test.ts
+++ b/tests/lambda/utils.test.ts
@@ -1,9 +1,5 @@
 import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import {
-  GetSecretValueCommand,
-  PutSecretValueCommand,
-  SecretsManagerClient,
-} from "@aws-sdk/client-secrets-manager";
+import { GetSecretValueCommand, PutSecretValueCommand, SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
 import { mockClient } from "aws-sdk-client-mock";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -17,8 +13,7 @@ import {
 const s3Mock = mockClient(S3Client);
 const secretsManagerMock = mockClient(SecretsManagerClient);
 const mockedS3Client: S3Client = s3Mock as unknown as S3Client;
-const mockedSecretsManagerClient: SecretsManagerClient =
-  secretsManagerMock as unknown as SecretsManagerClient;
+const mockedSecretsManagerClient: SecretsManagerClient = secretsManagerMock as unknown as SecretsManagerClient;
 
 describe("Utils", () => {
   beforeEach(() => {
@@ -78,9 +73,7 @@ describe("Utils", () => {
       process.env.MAX_TOKEN_VALIDITY_DURATION_SECONDS = "3600";
       process.env.KEY_SPEC = JSON.stringify({ algorithm: "RS256" });
 
-      expect(() => getEnvironmentConfig()).toThrow(
-        "MIN_ACTIVATION_GRACE_PERIOD_SECONDS must be a valid number",
-      );
+      expect(() => getEnvironmentConfig()).toThrow("MIN_ACTIVATION_GRACE_PERIOD_SECONDS must be a valid number");
     });
 
     it("should throw error when KEY_SPEC is invalid JSON", () => {
@@ -137,17 +130,15 @@ describe("Utils", () => {
         VersionStages: ["AWSCURRENT"],
       });
 
-      await expect(
-        getSecretValue(mockedSecretsManagerClient, { SecretId: "test-secret" }),
-      ).rejects.toThrow("Secret version has no VersionId");
+      await expect(getSecretValue(mockedSecretsManagerClient, { SecretId: "test-secret" })).rejects.toThrow(
+        "Secret version has no VersionId",
+      );
     });
 
     it("should throw error for other AWS errors", async () => {
       secretsManagerMock.on(GetSecretValueCommand).rejects(new Error("AWS Error"));
 
-      await expect(
-        getSecretValue(secretsManagerMock as any, { SecretId: "test-secret" }),
-      ).rejects.toThrow("AWS Error");
+      await expect(getSecretValue(secretsManagerMock as any, { SecretId: "test-secret" })).rejects.toThrow("AWS Error");
     });
   });
 
@@ -227,17 +218,15 @@ describe("Utils", () => {
         } as any,
       });
 
-      await expect(
-        getJwksFromS3(mockedS3Client, "test-bucket", ".well-known/jwks.json"),
-      ).rejects.toThrow("Empty response from S3");
+      await expect(getJwksFromS3(mockedS3Client, "test-bucket", ".well-known/jwks.json")).rejects.toThrow(
+        "Empty response from S3",
+      );
     });
 
     it("should handle other S3 errors", async () => {
       s3Mock.on(GetObjectCommand).rejects(new Error("S3 Error"));
 
-      await expect(
-        getJwksFromS3(mockedS3Client, "test-bucket", ".well-known/jwks.json"),
-      ).rejects.toThrow("S3 Error");
+      await expect(getJwksFromS3(mockedS3Client, "test-bucket", ".well-known/jwks.json")).rejects.toThrow("S3 Error");
     });
   });
 
@@ -249,12 +238,7 @@ describe("Utils", () => {
 
       s3Mock.on(PutObjectCommand).resolves({});
 
-      const result = await updateJwksFile(
-        mockedS3Client,
-        "test-bucket",
-        ".well-known/jwks.json",
-        mockJwks,
-      );
+      const result = await updateJwksFile(mockedS3Client, "test-bucket", ".well-known/jwks.json", mockJwks);
 
       expect(result).toEqual(mockJwks);
       expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);


### PR DESCRIPTION
## Summary

Bumps biome's formatter `lineWidth` from 100 → 120 and reformats the repo accordingly. Formatting-only; no logic changes.

```diff
 "formatter": {
   "indentStyle": "space",
-  "lineWidth": 100
+  "lineWidth": 120
 }
```

Reformatted 8 files via `biome format --write`; `biome check` passes. Committed as `style:` so semantic-release does **not** cut a release on merge.

This is intentionally a standalone change against `main`. It overlaps with the toolchain migration in #7 (which removes biome and sets oxfmt to 120) — if this merges first, #7 will be rebased; the net formatting result is identical, so any conflicts are mechanical.

Link to Devin session: https://app.devin.ai/sessions/3bdfc4e1eef54b07af2479fdcd73e0f3
Requested by: @oxc