### PR TITLE
chore: migrate release-drafter version-resolver to category-based config

### DIFF
--- a/.github/release-drafter-prerelease.yml
+++ b/.github/release-drafter-prerelease.yml
@@ -21,8 +21,10 @@ categories:
         - patch
   - type: version-resolver
     semver-increment: patch
-exclude-labels:
-  - ignore-for-release
+  - type: pre-exclude
+    when:
+      labels:
+        - ignore-for-release
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
 template: |

--- a/.github/release-drafter-prerelease.yml
+++ b/.github/release-drafter-prerelease.yml
@@ -3,17 +3,24 @@ name-template: 'v$RESOLVED_VERSION 🧪'
 tag-template: 'v$RESOLVED_VERSION'
 prerelease: true
 prerelease-identifier: rc
-version-resolver:
-  major:
-    labels:
-      - major
-  minor:
-    labels:
-      - minor
-  patch:
-    labels:
-      - patch
-  default: patch
+categories:
+  - type: version-resolver
+    semver-increment: major
+    when:
+      labels:
+        - major
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      labels:
+        - minor
+  - type: version-resolver
+    semver-increment: patch
+    when:
+      labels:
+        - patch
+  - type: version-resolver
+    semver-increment: patch
 exclude-labels:
   - ignore-for-release
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,17 +1,24 @@
 # cf https://github.com/marketplace/actions/release-drafter
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
-version-resolver:
-  major:
-    labels:
-      - major
-  minor:
-    labels:
-      - minor
-  patch:
-    labels:
-      - patch
-  default: patch
+categories:
+  - type: version-resolver
+    semver-increment: major
+    when:
+      labels:
+        - major
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      labels:
+        - minor
+  - type: version-resolver
+    semver-increment: patch
+    when:
+      labels:
+        - patch
+  - type: version-resolver
+    semver-increment: patch
 exclude-labels:
   - ignore-for-release
 autolabeler:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,8 +19,10 @@ categories:
         - patch
   - type: version-resolver
     semver-increment: patch
-exclude-labels:
-  - ignore-for-release
+  - type: pre-exclude
+    when:
+      labels:
+        - ignore-for-release
 autolabeler:
   - label: major
     title:


### PR DESCRIPTION
## Summary

Silences the Release Drafter deprecation warning:

> Use of deprecated 'version-resolver.patch.labels' field detected.

Release Drafter ([#1558](https://github.com/release-drafter/release-drafter/pull/1558)) unified config around `categories` and deprecated the standalone top-level `version-resolver:` and `exclude-labels:` settings (they still work via back-compat translation, but will be removed in a future major). This moves both into `categories` entries, in `release-drafter.yml` and `release-drafter-prerelease.yml`.

```diff
-version-resolver:
-  major: { labels: [major] }
-  minor: { labels: [minor] }
-  patch: { labels: [patch] }
-  default: patch
-exclude-labels:
-  - ignore-for-release
+categories:
+  - { type: version-resolver, semver-increment: major, when: { labels: [major] } }
+  - { type: version-resolver, semver-increment: minor, when: { labels: [minor] } }
+  - { type: version-resolver, semver-increment: patch, when: { labels: [patch] } }
+  - { type: version-resolver, semver-increment: patch }   # no `when` → default
+  - { type: pre-exclude, when: { labels: [ignore-for-release] } }
```

Behavior is unchanged: the resolver still picks the highest matched increment, the trailing condition-less `version-resolver` entry reproduces the old `default: patch`, and `pre-exclude` keeps `ignore-for-release` PRs out of the notes. `autolabeler` is untouched, and since the resolver/exclude categories aren't changelog (`title`) categories, the rendered notes stay a flat `$CHANGES` list.

Part of a cross-repo cleanup (same change in react-router-aws, react-router-sessions-dynamodb, hamstore).

Link to Devin session: https://app.devin.ai/sessions/3bdfc4e1eef54b07af2479fdcd73e0f3
Requested by: @oxc